### PR TITLE
Fix handling of UTF-8 coming back from PT

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+- Fix handling of UTF-8 characters in the 128-255 in data coming back from
+  PT. These would end up being double-decoded, leading the dreaded �. GH #16
+  for App-GHPT.
+
+
 0.07     2017-02-08
 
 - Re-release with latest dzil bundle to fix documentation. Reported by Dave


### PR DESCRIPTION
We want to explicit _not_ enable the Cpanel::JSON::XS utf8 flag when
decoding. This flag tells the decoder that the data you are giving it is byte
data and should be decoded. However, it seems like LWP is already decoding the
data for us.