### PR TITLE
Explicitly require LWP::Protocol::https

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@
 
 - Add the ability to look up project memberships.
 
+- Make sure that LWP::Protocol::https is listed as an explicit dependency. The
+  PT API uses HTTPS so we need this module to talk to it.
+
 
 0.10     2018-01-04
 

--- a/lib/WebService/PivotalTracker/Client.pm
+++ b/lib/WebService/PivotalTracker/Client.pm
@@ -8,6 +8,7 @@ our $VERSION = '0.11';
 
 use Cpanel::JSON::XS qw( decode_json encode_json );
 use HTTP::Request;
+use LWP::Protocol::https;
 use LWP::UserAgent;
 use URI;
 use WebService::PivotalTracker::Types qw( LWPObject MD5Hex Uri );


### PR DESCRIPTION
We want this to be included in our deps because the PT API is HTTPS only.